### PR TITLE
Fix blocking calls

### DIFF
--- a/src/main/java/com/github/rawsanj/handler/WebHttpHandler.java
+++ b/src/main/java/com/github/rawsanj/handler/WebHttpHandler.java
@@ -9,6 +9,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.scheduler.Schedulers;
 
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
@@ -23,7 +24,9 @@ public class WebHttpHandler {
 		return route(GET("/"), request -> ok().contentType(MediaType.TEXT_HTML).bodyValue(html))
 			.andRoute(POST("/message"), request -> request.bodyToMono(Message.class)
 				.flatMap(message -> redisChatMessagePublisher.publishChatMessage(message.getMessage()))
-				.flatMap(aLong -> ServerResponse.ok().bodyValue(new Message("Message Sent Successfully!."))));
+				.flatMap(aLong -> ServerResponse.ok().bodyValue(new Message("Message Sent Successfully!.")))
+					.subscribeOn(Schedulers.boundedElastic()));
+
 	}
 
 }


### PR DESCRIPTION
Hi! 👋 

Apparently the chat module has some blocking calls (as detected by BlockHound):
<img width="1334" alt="Screen Shot 2023-07-15 at 1 51 11 AM" src="https://github.com/RawSanj/spring-redis-websocket/assets/56495631/6f2ae5d7-9065-4901-a6e1-645473625a17">
<img width="1297" alt="Screen Shot 2023-07-15 at 1 57 33 AM" src="https://github.com/RawSanj/spring-redis-websocket/assets/56495631/1c97166f-c5d9-4920-80af-69c2b7e45c09">


This PR addresses these blocking code to ensure the pipeline remain reactive.